### PR TITLE
Since June 15th, 2021, the building on travis-ci.org is ceased. Pleas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The source code for netboot.xyz is located [here](https://github.com/netbootxyz/
 
 ## Contributing
 
-New version of an operating system out? Found one that network boots well with iPXE? Pull requests are welcomed and encouraged and helps out a ton! Feel free to issue a pull request for new versions or tools that you might find useful. Once merged into master, [Travis CI](https://travis-ci.org/netbootxyz/netboot.xyz) will regenerate new versions of [iPXE from upstream](https://github.com/ipxe/ipxe) and deploy the latest changes to netboot.xyz. See more on contributing [here](https://netboot.xyz/contributing).
+New version of an operating system out? Found one that network boots well with iPXE? Pull requests are welcomed and encouraged and helps out a ton! Feel free to issue a pull request for new versions or tools that you might find useful. Once merged into master, [Travis CI](https://travis-ci.com/netbootxyz/netboot.xyz) will regenerate new versions of [iPXE from upstream](https://github.com/ipxe/ipxe) and deploy the latest changes to netboot.xyz. See more on contributing [here](https://netboot.xyz/contributing).
 
 ## Testing New Branches
 


### PR DESCRIPTION
…e use travis-ci.com from now on.